### PR TITLE
Add consistent avatars for users and cards

### DIFF
--- a/components/board.tsx
+++ b/components/board.tsx
@@ -13,6 +13,7 @@ import { AddCardButton } from "@/components/add-card-button";
 import { CommandMenu } from "@/components/command-menu";
 import { generateUsername } from "@/lib/names";
 import { generateCardId } from "@/lib/nanoid";
+import { getAvatarForUser } from "@/lib/utils";
 import { createCard, updateCard, deleteCard, voteCard as voteCardAction } from "@/app/actions";
 import type { Card } from "@/db/schema";
 import { Share2, Home, Plus, Command, Copy, Check, Minus, Maximize2 } from "lucide-react";
@@ -274,7 +275,7 @@ export function Board({ sessionId, initialCards }: BoardProps) {
             <Home className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
           </Button>
         </Link>
-        <UserBadge username={username} />
+        <UserBadge username={username} avatar={getAvatarForUser(visitorId)} />
       </div>
 
       {/* Fixed UI - Top Right */}

--- a/components/idea-card.tsx
+++ b/components/idea-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useTheme } from "next-themes";
+import Image from "next/image";
 import NumberFlow from "@number-flow/react";
 import { motion, AnimatePresence } from "motion/react";
 import { Textarea } from "@/components/ui/textarea";
@@ -18,6 +19,7 @@ import {
 } from "@/components/ui/tooltip";
 import { X, GripVertical, ChevronUp, Sparkles, Loader2, Undo2, Maximize2, Minimize2, Copy, Check } from "lucide-react";
 import Markdown from "react-markdown";
+import { getAvatarForUser } from "@/lib/utils";
 import type { Card } from "@/db/schema";
 
 const LIGHT_COLORS = [
@@ -514,9 +516,18 @@ export function IdeaCard({
           )}
         </div>
         <div className={`flex items-center justify-between px-2.5 sm:px-3.5 py-2 sm:py-2.5 border-t ${borderClass}`}>
-          <span className={`text-[10px] sm:text-[11px] ${mutedTextClass} truncate max-w-[70px] sm:max-w-[100px] font-medium`}>
-            {card.createdBy}
-          </span>
+          <div className="flex items-center gap-1 sm:gap-1.5">
+            <Image
+              src={getAvatarForUser(card.createdBy)}
+              alt={`${card.createdBy}'s avatar`}
+              width={16}
+              height={16}
+              className="w-4 h-4 sm:w-5 sm:h-5"
+            />
+            <span className={`text-[10px] sm:text-[11px] ${mutedTextClass} truncate max-w-[55px] sm:max-w-[80px] font-medium`}>
+              {card.createdBy}
+            </span>
+          </div>
           <TooltipProvider delayDuration={400}>
             <div
               className="flex items-center gap-1 sm:gap-1.5"

--- a/components/user-badge.tsx
+++ b/components/user-badge.tsx
@@ -1,28 +1,17 @@
 "use client";
 
 import Image from "next/image";
-import { useMemo } from "react";
-
-const CAT_AVATARS = [
-  "/cat-blue.svg",
-  "/cat-green.svg",
-  "/cat-purple.svg",
-  "/cat-yellow.svg",
-];
 
 interface UserBadgeProps {
   username: string;
+  avatar: string;
 }
 
-export function UserBadge({ username }: UserBadgeProps) {
-  const avatarSrc = useMemo(() => {
-    return CAT_AVATARS[Math.floor(Math.random() * CAT_AVATARS.length)];
-  }, []);
-
+export function UserBadge({ username, avatar }: UserBadgeProps) {
   return (
     <div className="inline-flex items-center gap-2 px-2 sm:px-3 h-8 sm:h-9 rounded-md bg-card/80 backdrop-blur-sm border border-border shadow-xs dark:bg-input/30 dark:border-input">
       <Image
-        src={avatarSrc}
+        src={avatar}
         alt="Avatar"
         width={20}
         height={20}

--- a/drizzle/0000_chunky_vapor.sql
+++ b/drizzle/0000_chunky_vapor.sql
@@ -1,18 +1,25 @@
-CREATE TABLE "cards" (
+CREATE TABLE IF NOT EXISTS "cards" (
 	"id" text PRIMARY KEY NOT NULL,
 	"session_id" text NOT NULL,
 	"content" text DEFAULT '' NOT NULL,
 	"color" text DEFAULT '#fef08a' NOT NULL,
 	"x" real DEFAULT 100 NOT NULL,
 	"y" real DEFAULT 100 NOT NULL,
+	"votes" integer DEFAULT 0 NOT NULL,
+	"voted_by" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_by_id" text NOT NULL,
 	"created_by" text NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "sessions" (
+CREATE TABLE IF NOT EXISTS "sessions" (
 	"id" text PRIMARY KEY NOT NULL,
 	"name" text NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "cards" ADD CONSTRAINT "cards_session_id_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;
+DO $$ BEGIN
+  ALTER TABLE "cards" ADD CONSTRAINT "cards_session_id_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/drizzle/0001_add_votes.sql
+++ b/drizzle/0001_add_votes.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "cards" ADD COLUMN "votes" integer DEFAULT 0 NOT NULL;
-

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "6a4aebea-31bd-46a7-9f32-f337c90072e4",
+  "id": "f52c06e8-42fd-44a6-9a84-788084739ae4",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -47,6 +47,26 @@
           "primaryKey": false,
           "notNull": true,
           "default": 100
+        },
+        "votes": {
+          "name": "votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "voted_by": {
+          "name": "voted_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
         },
         "created_by": {
           "name": "created_by",

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,15 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1766881189157,
-      "tag": "0000_flashy_lord_hawal",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1735344000000,
-      "tag": "0001_add_votes",
+      "when": 1767044822651,
+      "tag": "0000_chunky_vapor",
       "breakpoints": true
     }
   ]

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,23 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+const CAT_AVATARS = [
+  "/cat-blue.svg",
+  "/cat-green.svg",
+  "/cat-purple.svg",
+  "/cat-yellow.svg",
+];
+
+/**
+ * Generate a consistent avatar based on a string (username or visitorId)
+ * The same input will always return the same avatar
+ */
+export function getAvatarForUser(identifier: string): string {
+  let hash = 0;
+  for (let i = 0; i < identifier.length; i++) {
+    hash = ((hash << 5) - hash) + identifier.charCodeAt(i);
+    hash = hash & hash;
+  }
+  return CAT_AVATARS[Math.abs(hash) % CAT_AVATARS.length];
+}


### PR DESCRIPTION
Replace random avatars in UserBadge with deterministic avatars based on username or visitor ID. Show avatars next to card creators and in user badges. Update database schema snapshot and migration to include votes and creator ID fields.

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/a1d6b577-5098-4a25-9a01-ce0a266f8134" />
