### PR TITLE
feat: add N keyboard shortcut to create new card

### DIFF
--- a/components/add-card-button.tsx
+++ b/components/add-card-button.tsx
@@ -2,6 +2,12 @@
 
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface AddCardButtonProps {
   onClick: () => void;
@@ -9,13 +15,22 @@ interface AddCardButtonProps {
 
 export function AddCardButton({ onClick }: AddCardButtonProps) {
   return (
-    <Button
-      onClick={onClick}
-      variant="outline"
-      size="icon"
-      className="h-8 w-8 sm:h-9 sm:w-9 bg-card/80 backdrop-blur-sm border-border"
-    >
-      <Plus className="w-4 h-4" />
-    </Button>
+    <TooltipProvider delayDuration={400}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={onClick}
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 sm:h-9 sm:w-9 bg-card/80 backdrop-blur-sm border-border"
+          >
+            <Plus className="w-4 h-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p>Add card <kbd className="ml-1 px-1.5 py-0.5 text-xs bg-muted rounded">N</kbd></p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/components/board.tsx
+++ b/components/board.tsx
@@ -197,12 +197,12 @@ export function Board({ sessionId, initialCards, initialParticipants }: BoardPro
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [fitAllCards]);
 
-  const getRandomColor = () => {
+  const getRandomColor = useCallback(() => {
     const colors = resolvedTheme === "dark" ? DARK_COLORS : LIGHT_COLORS;
     return colors[Math.floor(Math.random() * colors.length)];
-  };
+  }, [resolvedTheme]);
 
-  const handleAddCard = async () => {
+  const handleAddCard = useCallback(async () => {
     if (!username || !visitorId) return;
     playSound();
 
@@ -239,7 +239,7 @@ export function Board({ sessionId, initialCards, initialParticipants }: BoardPro
     setNewCardId(cardId);
     addCard(newCard);
     await createCard(newCard);
-  };
+  }, [username, visitorId, playSound, screenToWorld, sessionId, getRandomColor, addCard]);
 
   const handlePersistContent = async (id: string, content: string) => {
     await updateCard(id, { content });
@@ -298,6 +298,32 @@ export function Board({ sessionId, initialCards, initialParticipants }: BoardPro
     }
     return result;
   };
+
+  // Keyboard shortcut for new card (key "N")
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Skip if user is typing in an input or textarea
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
+        return;
+      }
+      
+      // Skip if command menu is open
+      if (commandOpen) {
+        return;
+      }
+
+      // "N" to create a new card
+      if (e.key === "n" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        handleAddCard();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [commandOpen, handleAddCard]);
 
   if (!username || isFingerprintLoading || isUsernameLoading || !visitorId) {
     return (
@@ -369,6 +395,7 @@ export function Board({ sessionId, initialCards, initialParticipants }: BoardPro
           size="icon"
           onClick={handleAddCard}
           className="bg-card/80 backdrop-blur-sm h-8 w-8 sm:h-9 sm:w-9"
+          title="Add card (N)"
         >
           <Plus className="w-4 h-4" />
         </Button>

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -51,7 +51,7 @@ export function CommandMenu({ open, onOpenChange, onAddCard, onShare, onChangeNa
           <CommandItem onSelect={() => runCommand(onAddCard)}>
             <Plus className="mr-2 h-4 w-4" />
             Add new card
-            <CommandShortcut>⌘N</CommandShortcut>
+            <CommandShortcut>N</CommandShortcut>
           </CommandItem>
           <CommandItem onSelect={() => runCommand(onShare)}>
             <Share2 className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary

- Add `N` keyboard shortcut to quickly create a new card from anywhere on the board
- Shortcut is disabled when typing in inputs (card text, name dialog) or when command menu is open
- Add tooltip hints to both "Add card" buttons showing the keyboard shortcut

## Changes

- `components/board.tsx`: Add keyboard event listener + memoize `handleAddCard`
- `components/add-card-button.tsx`: Add Tooltip with shortcut hint
- `components/command-menu.tsx`: Update shortcut display from `⌘N` to `N`