### PR TITLE
feat: add minimap (#27)

### DIFF
--- a/components/board.tsx
+++ b/components/board.tsx
@@ -1,6 +1,25 @@
 "use client";
 
 import {
+  Check,
+  Command,
+  Copy,
+  Home,
+  Lock,
+  Maximize2,
+  Menu,
+  Minus,
+  Pencil,
+  Plus,
+  Settings,
+  Share2,
+  Trash,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
   createCard,
   deleteCard,
   deleteEmptyCards,
@@ -43,25 +62,6 @@ import { DARK_COLORS, LIGHT_COLORS } from "@/lib/colors";
 import { generateCardId } from "@/lib/nanoid";
 import { canAddCard } from "@/lib/permissions";
 import { getAvatarForUser } from "@/lib/utils";
-import {
-  Check,
-  Command,
-  Copy,
-  Home,
-  Lock,
-  Maximize2,
-  Menu,
-  Minus,
-  Pencil,
-  Plus,
-  Settings,
-  Share2,
-  Trash,
-} from "lucide-react";
-import { useTheme } from "next-themes";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface Participant {
   visitorId: string;
@@ -98,7 +98,7 @@ export function Board({
   const [session, setSession] = useState<Session>(initialSession);
   const [userRole, setUserRole] = useState<SessionRole | null>(null);
   const [participants, setParticipants] = useState<Map<string, string>>(
-    () => new Map(initialParticipants.map((p) => [p.visitorId, p.username]))
+    () => new Map(initialParticipants.map((p) => [p.visitorId, p.username])),
   );
   const hasInitializedViewRef = useRef(false);
   const { resolvedTheme } = useTheme();
@@ -166,7 +166,7 @@ export function Board({
     (userId: string): string => {
       return participants.get(userId) ?? "Unknown";
     },
-    [participants]
+    [participants],
   );
 
   const {
@@ -189,7 +189,7 @@ export function Board({
     (worldPoint: { x: number; y: number }) => {
       centerOn(worldPoint, zoom); // Keep current zoom level
     },
-    [centerOn, zoom]
+    [centerOn, zoom],
   );
 
   // Handle minimap zoom
@@ -202,7 +202,7 @@ export function Board({
       const screenPoint = worldToScreen(worldPoint);
       zoomTo(newZoom, screenPoint);
     },
-    [zoom, zoomTo, worldToScreen]
+    [zoom, zoomTo, worldToScreen],
   );
 
   // Handle incoming name change events from realtime
@@ -214,7 +214,7 @@ export function Board({
         return next;
       });
     },
-    []
+    [],
   );
 
   // Handle incoming session rename events from realtime
@@ -227,7 +227,7 @@ export function Board({
     (settings: SessionSettings) => {
       setSession((prev) => ({ ...prev, ...settings }));
     },
-    []
+    [],
   );
 
   const {
@@ -249,7 +249,7 @@ export function Board({
     username,
     handleRemoteNameChange,
     handleRemoteSessionRename,
-    handleRemoteSessionSettingsChange
+    handleRemoteSessionSettingsChange,
   );
 
   // Fit all cards in view
@@ -270,7 +270,7 @@ export function Board({
         maxX: Math.max(acc.maxX, card.x + cardWidth),
         maxY: Math.max(acc.maxY, card.y + cardHeight),
       }),
-      { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+      { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
     );
 
     fitToBounds(bounds);
@@ -296,7 +296,7 @@ export function Board({
         maxX: Math.max(acc.maxX, card.x + cardWidth),
         maxY: Math.max(acc.maxY, card.y + cardHeight),
       }),
-      { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+      { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
     );
 
     // Center on cards at 100% zoom
@@ -493,7 +493,7 @@ export function Board({
     const { session: updatedSession, error } = await updateSessionName(
       sessionId,
       newName,
-      visitorId
+      visitorId,
     );
     if (updatedSession && !error) {
       // Update local state
@@ -515,7 +515,7 @@ export function Board({
     const { session: updatedSession, error } = await updateSessionSettings(
       sessionId,
       settings,
-      visitorId
+      visitorId,
     );
     if (updatedSession && !error) {
       // Update local state
@@ -548,7 +548,7 @@ export function Board({
 
     const { deletedIds, deletedCount, error } = await deleteEmptyCards(
       sessionId,
-      visitorId
+      visitorId,
     );
 
     if (error) {
@@ -896,7 +896,7 @@ export function Board({
       </div>
 
       {/* Minimap (Desktop Only) */}
-      {window.innerWidth >= 640 && (
+      {viewportSize.width >= 640 && (
         <div className="fixed top-20 right-4 z-50">
           <Minimap
             cards={cards}

--- a/components/idea-card.tsx
+++ b/components/idea-card.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+import NumberFlow from "@number-flow/react";
+import {
+  Check,
+  ChevronUp,
+  Copy,
+  GripVertical,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  Smile,
+  Sparkles,
+  Undo2,
+  X,
+} from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import Image from "next/image";
+import { useTheme } from "next-themes";
+import { useEffect, useRef, useState } from "react";
+import Markdown from "react-markdown";
 import {
   Popover,
   PopoverContent,
@@ -28,25 +47,6 @@ import {
   canVote,
 } from "@/lib/permissions";
 import { getAvatarForUser } from "@/lib/utils";
-import NumberFlow from "@number-flow/react";
-import {
-  Check,
-  ChevronUp,
-  Copy,
-  GripVertical,
-  Loader2,
-  Maximize2,
-  Minimize2,
-  Smile,
-  Sparkles,
-  Undo2,
-  X,
-} from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
-import { useTheme } from "next-themes";
-import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
-import Markdown from "react-markdown";
 
 const REACTION_EMOJIS = ["👍", "❤️", "🔥", "💡", "🎯"] as const;
 
@@ -123,7 +123,7 @@ export function IdeaCard({
     session,
     card,
     visitorId,
-    userRole ?? "participant"
+    userRole ?? "participant",
   );
   const allowChangeColor = canChangeColor(session, card, visitorId);
   const allowRefine = canRefine(session, card, visitorId);
@@ -328,8 +328,8 @@ export function IdeaCard({
       ? "bg-black/10"
       : "bg-transparent group-hover:bg-black/10"
     : isMobile
-    ? "bg-stone-900/5"
-    : "bg-transparent group-hover:bg-stone-900/5";
+      ? "bg-stone-900/5"
+      : "bg-transparent group-hover:bg-stone-900/5";
 
   return (
     <motion.div
@@ -704,8 +704,8 @@ export function IdeaCard({
                     hasReacted
                       ? "bg-stone-900/15 cursor-pointer"
                       : allowReact
-                      ? `${hoverBgClass} cursor-pointer`
-                      : "opacity-50 cursor-default"
+                        ? `${hoverBgClass} cursor-pointer`
+                        : "opacity-50 cursor-default"
                   }`}
                 >
                   <span>{emoji}</span>
@@ -813,10 +813,10 @@ export function IdeaCard({
                       !allowVote
                         ? "opacity-30 cursor-not-allowed"
                         : hasVoted
-                        ? isPurpleDark
-                          ? "bg-white/20 text-white"
-                          : "bg-stone-900/15 text-stone-800"
-                        : `${hoverBgClass} cursor-pointer`
+                          ? isPurpleDark
+                            ? "bg-white/20 text-white"
+                            : "bg-stone-900/15 text-stone-800"
+                          : `${hoverBgClass} cursor-pointer`
                     }`}
                   >
                     <ChevronUp
@@ -834,10 +834,10 @@ export function IdeaCard({
                   {isOwnCard
                     ? "Can't vote on your own"
                     : session.isLocked
-                    ? "Session is locked"
-                    : hasVoted
-                    ? "Remove vote"
-                    : "Vote"}
+                      ? "Session is locked"
+                      : hasVoted
+                        ? "Remove vote"
+                        : "Vote"}
                 </TooltipContent>
               </Tooltip>
             </div>

--- a/components/minimap.tsx
+++ b/components/minimap.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { useTheme } from "next-themes";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@/db/schema";
 import { useMinimap } from "@/hooks/use-minimap";
 import { getDisplayColor } from "@/lib/colors";
 import { cn } from "@/lib/utils";
-import { useTheme } from "next-themes";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface MinimapProps {
   cards: Card[];
@@ -56,14 +56,14 @@ export function Minimap({
 
   const colors = useMemo(
     () => ({
-      background: isDark ? "hsl(224, 71%, 4%)" : "hsl(0, 0%, 98%)",
-      pattern: isDark ? "hsl(215, 25%, 27%)" : "hsl(0, 0%, 50%)",
-      patternOpacity: isDark ? 0.25 : 0.08,
-      viewportFill: isDark ? "hsl(210, 40%, 25%)" : "hsl(var(--primary))",
-      viewportFillOpacity: isDark ? 0.5 : 0.3,
-      viewportStroke: isDark ? "hsl(210, 60%, 55%)" : "hsl(var(--foreground))",
+      background: isDark ? "hsl(222, 47%, 11%)" : "hsl(0, 0%, 98%)",
+      pattern: isDark ? "hsl(215, 28%, 17%)" : "hsl(0, 0%, 50%)",
+      patternOpacity: isDark ? 0.35 : 0.08,
+      viewportFill: isDark ? "hsl(210, 100%, 60%)" : "hsl(var(--primary))",
+      viewportFillOpacity: isDark ? 0.18 : 0.3,
+      viewportStroke: isDark ? "hsl(0, 0%, 98%)" : "hsl(var(--foreground))",
     }),
-    [isDark]
+    [isDark],
   );
 
   const handlePointerDown = useCallback(
@@ -74,7 +74,7 @@ export function Minimap({
       const worldPoint = getWorldFromPointerEvent(e, rect);
       onNavigate(worldPoint);
     },
-    [getWorldFromPointerEvent, onNavigate]
+    [getWorldFromPointerEvent, onNavigate],
   );
 
   const handlePointerMove = useCallback(
@@ -84,7 +84,7 @@ export function Minimap({
       const worldPoint = getWorldFromPointerEvent(e, rect);
       onNavigate(worldPoint);
     },
-    [dragging, getWorldFromPointerEvent, onNavigate]
+    [dragging, getWorldFromPointerEvent, onNavigate],
   );
 
   const handlePointerUp = useCallback(() => setDragging(false), []);

--- a/hooks/use-minimap.ts
+++ b/hooks/use-minimap.ts
@@ -1,5 +1,5 @@
-import { Card } from "@/db/schema";
 import { useCallback, useLayoutEffect, useMemo, useState } from "react";
+import { Card } from "@/db/schema";
 
 // Card dimensions
 const CARD_SIZE = {
@@ -86,7 +86,7 @@ export function useMinimap({
       x: PADDING + (x - worldBounds.minX) * scale,
       y: PADDING + (y - worldBounds.minY) * scale,
     }),
-    [worldBounds, scale]
+    [worldBounds, scale],
   );
 
   const minimapToWorld = useCallback(
@@ -94,7 +94,7 @@ export function useMinimap({
       x: worldBounds.minX + (x - PADDING) / scale,
       y: worldBounds.minY + (y - PADDING) / scale,
     }),
-    [worldBounds, scale]
+    [worldBounds, scale],
   );
 
   const viewportWorld = useMemo(() => {
@@ -113,7 +113,7 @@ export function useMinimap({
     const tl = worldToMinimap(viewportWorld.x, viewportWorld.y);
     const br = worldToMinimap(
       viewportWorld.x + viewportWorld.w,
-      viewportWorld.y + viewportWorld.h
+      viewportWorld.y + viewportWorld.h,
     );
 
     return {
@@ -131,7 +131,7 @@ export function useMinimap({
 
       return minimapToWorld(x, y);
     },
-    [minimapSize, minimapToWorld]
+    [minimapSize, minimapToWorld],
   );
 
   return {

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,6 +1,18 @@
-export const LIGHT_COLORS = ["#D4B8F0", "#FFCAB0", "#C4EDBA", "#C5E8EC", "#F9E9A8"];
+export const LIGHT_COLORS = [
+  "#D4B8F0",
+  "#FFCAB0",
+  "#C4EDBA",
+  "#C5E8EC",
+  "#F9E9A8",
+];
 
-export const DARK_COLORS = ["#9B7BC7", "#E8936A", "#7BC96A", "#7ABCC5", "#D4C468"];
+export const DARK_COLORS = [
+  "#9B7BC7",
+  "#E8936A",
+  "#7BC96A",
+  "#7ABCC5",
+  "#D4C468",
+];
 
 export const COLOR_MAP: Record<string, string> = {
   "#D4B8F0": "#9B7BC7",
@@ -22,7 +34,7 @@ export const COLOR_MAP: Record<string, string> = {
 export function getDisplayColor(
   storedColor: string,
   isDark: boolean,
-  mounted: boolean
+  mounted: boolean,
 ): string {
   if (!mounted) return storedColor;
   const isStoredDark = DARK_COLORS.includes(storedColor);
@@ -34,4 +46,3 @@ export function getDisplayColor(
   }
   return storedColor;
 }
-


### PR DESCRIPTION
This PR adds a comprehensive minimap system to Pawboard, enabling intuitive navigation of large collaborative canvases.

✨ Key Features
- Interactive Navigation: Click & drag to pan, mouse wheel zoom
- Real-time Updates: Live reflection of card positions and viewport
- Responsive Design: Desktop-only (≥640px) for optimal mobile UX
- Dynamic Theming: Seamless light/dark mode support

🎨 Light mode:

<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/acd884c3-103c-4833-befd-d61cdc786806" />

<br>
<br>

🎨 Dark mode:

<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/c8c74215-506b-4ae0-b1af-efede7674426" />

<br>
<br>

Closes https://github.com/crafter-station/pawboard/issues/27