### PR TITLE
fix(#41): ensure paw cursors render above cards with z-index 2000

### DIFF
--- a/components/cursor.tsx
+++ b/components/cursor.tsx
@@ -31,6 +31,7 @@ export const Cursor = ({
   return (
     <motion.div
       className={cn("pointer-events-none absolute", className)}
+      style={{ zIndex: 2000 }}
       initial={{ x, y }}
       animate={{ x, y }}
       transition={{


### PR DESCRIPTION
The collaborative cursor indicators were rendering beneath card elements, making them invisible when positioned over cards. Added z-index: 2000 to the cursor component to ensure it always appears above cards (z-index up to 1000) and popovers (z-index 1001).