### PR TITLE
fix(cards): prevent text selection during card drag

### DIFF
--- a/components/idea-card.tsx
+++ b/components/idea-card.tsx
@@ -410,7 +410,7 @@ export function IdeaCard({
     <motion.div
       ref={cardRef}
       data-card
-      className={`absolute group touch-none transition-[width] duration-200 ${
+      className={`absolute group touch-none select-none transition-[width] duration-200 ${
         isExpanded ? "w-72 sm:w-96" : "w-40 sm:w-56"
       }`}
       initial={{ x: card.x, y: card.y }}


### PR DESCRIPTION
## Summary
- Add `select-none` class to card wrapper to prevent unwanted text selection during drag operations

## Fixes
Closes #60

## Details
When dragging cards, the browser's default text selection behavior was interfering with the drag-and-drop experience. This fix applies `user-select: none` to the card wrapper element, preventing text selection while still allowing normal text selection within the textarea when editing card content.

The fix is minimal and targeted - just adding the `select-none` Tailwind class to the existing className string on the card's `motion.div` wrapper.