### PR TITLE
fix: show drag cursor only on draggable areas

### DIFF
--- a/components/idea-card.tsx
+++ b/components/idea-card.tsx
@@ -448,6 +448,12 @@ export function IdeaCard({
     }
   };
 
+  const getCursorStyle = () => {
+    if (!allowMove) return "default";
+    if (isDragging) return "grabbing";
+    return "grab";
+  };
+
   const isPurpleCard =
     card.color === LIGHT_COLORS[0] || card.color === DARK_COLORS[0];
   const isPurpleDark = isPurpleCard && isDark;
@@ -483,7 +489,6 @@ export function IdeaCard({
         stiffness: 350,
       }}
       style={{
-        cursor: allowMove ? (isDragging ? "grabbing" : "grab") : "default",
         zIndex: isDragging ? 1000 : isExpanded ? 100 : 1,
         pointerEvents: isSpacePressed ? "none" : "auto",
       }}
@@ -508,6 +513,9 @@ export function IdeaCard({
         />
         <div
           className={`flex items-center justify-between px-2.5 py-1.5 sm:px-3 sm:py-2 border-b ${borderClass}`}
+          style={{
+            cursor: getCursorStyle(),
+          }}
         >
           <GripVertical
             className={`w-3.5 h-3.5 sm:w-4 sm:h-4 ${iconClass} ${
@@ -881,6 +889,9 @@ export function IdeaCard({
         )}
         <div
           className={`flex items-center justify-between px-2.5 sm:px-3.5 py-2 sm:py-2.5 border-t ${borderClass}`}
+          style={{
+            cursor: getCursorStyle(),
+          }}
         >
           <div className="flex items-center gap-1 sm:gap-1.5">
             <Image


### PR DESCRIPTION
## Summary
Fixes misleading drag cursor behavior by restricting the grab cursor to only draggable areas (header and footer) of idea cards, preventing confusion when hovering over non-draggable card body edges.

## Technical Details

### Cursor Style Refactoring
- Extracted cursor logic into `getCursorStyle()` helper function for reusability
- Removed cursor style from main card container (`motion.div`)
- Applied cursor style only to header and footer divs (the actual draggable areas)
- Card body maintains appropriate cursor (text cursor when editable, default otherwise)

### User Experience
- **Before**: Cursor showed "grab" when hovering over card body edges, but dragging didn't work
- **After**: Cursor only shows "grab" on header and footer where dragging is actually supported

## User Interaction Flow
- Hover over card header: Shows grab cursor
- Hover over card footer: Shows grab cursor
- Hover over card body edges: Shows default/text cursor (no misleading grab cursor)
- Drag from header/footer: Works as expected

## Testing
✅ Build successful with no TypeScript errors
✅ Linter passed
✅ Cursor behavior verified on header, footer, and body areas
✅ Drag functionality confirmed working only from draggable areas

Closes #66 