### PR TITLE
fix: prevent avatar drag on idea card

### DIFF
--- a/components/idea-card.tsx
+++ b/components/idea-card.tsx
@@ -889,6 +889,7 @@ export function IdeaCard({
               width={16}
               height={16}
               className="w-4 h-4 sm:w-5 sm:h-5"
+              draggable={false}
             />
             <span
               className={`text-[10px] sm:text-[11px] ${mutedTextClass} truncate max-w-13.75 sm:max-w-20 font-medium`}


### PR DESCRIPTION
## Summary
Prevents the creator avatar image from being accidentally dragged when interacting with idea cards, improving the user experience by ensuring only the card itself can be dragged.

## Technical Details

### Image Drag Prevention
- Added `draggable={false}` attribute to the creator avatar `Image` component in the card footer
- Prevents browser's default image drag behavior that could interfere with card dragging

## User Experience
- **Before**: Avatar image could be dragged separately from the card, causing confusion
- **After**: Avatar image is no longer draggable, only the card can be moved

## Testing
✅ Build successful with no TypeScript errors
✅ Linter passed
✅ Avatar drag prevention verified
✅ Card dragging functionality confirmed working

Closes #71 