### PR TITLE
feat(cards): add resizable cards with realtime sync and cursor fixes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -267,3 +267,23 @@
 .react-flow__background {
   background-color: hsl(var(--background));
 }
+
+/* Card resize handles - Safari fix */
+/* Override React Flow's grab cursor on nodes when hovering resize handles */
+.react-flow__node.draggable:has(.resize-handle-e:hover),
+.react-flow__node.draggable:has(.resize-handle-s:hover),
+.react-flow__node.draggable:has(.resize-handle-se:hover) {
+  cursor: auto !important;
+}
+
+.resize-handle-e {
+  cursor: ew-resize !important;
+}
+
+.resize-handle-s {
+  cursor: ns-resize !important;
+}
+
+.resize-handle-se {
+  cursor: nwse-resize !important;
+}

--- a/components/realtime-cursors.tsx
+++ b/components/realtime-cursors.tsx
@@ -14,12 +14,14 @@ interface RealtimeCursorsProps {
   roomName: string;
   username: string;
   screenToWorld: (screen: Point) => Point;
+  worldToScreen: (world: Point) => Point;
 }
 
 export const RealtimeCursors = ({
   roomName,
   username,
   screenToWorld,
+  worldToScreen,
 }: RealtimeCursorsProps) => {
   const { cursors } = useRealtimeCursors({
     roomName,
@@ -30,16 +32,19 @@ export const RealtimeCursors = ({
 
   return (
     <div className="pointer-events-none">
-      {Object.keys(cursors).map((id) => (
-        <Cursor
-          key={id}
-          x={cursors[id].position.x}
-          y={cursors[id].position.y}
-          color={cursors[id].color}
-          cursorImage={cursors[id].cursorImage}
-          name={cursors[id].user.name}
-        />
-      ))}
+      {Object.keys(cursors).map((id) => {
+        const screenPos = worldToScreen(cursors[id].position);
+        return (
+          <Cursor
+            key={id}
+            x={screenPos.x}
+            y={screenPos.y}
+            color={cursors[id].color}
+            cursorImage={cursors[id].cursorImage}
+            name={cursors[id].user.name}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -67,6 +67,8 @@ export const cards = pgTable(
     color: text("color").notNull().default("#fef08a"),
     x: real("x").notNull().default(100),
     y: real("y").notNull().default(100),
+    width: integer("width").notNull().default(224),
+    height: integer("height").notNull().default(160),
     votes: integer("votes").notNull().default(0),
     votedBy: jsonb("voted_by").$type<string[]>().notNull().default([]),
     reactions: jsonb("reactions")

--- a/drizzle/0008_uneven_loki.sql
+++ b/drizzle/0008_uneven_loki.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "cards" ADD COLUMN IF NOT EXISTS "width" integer DEFAULT 224 NOT NULL;--> statement-breakpoint
+ALTER TABLE "cards" ADD COLUMN IF NOT EXISTS "height" integer DEFAULT 160 NOT NULL;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,343 @@
+{
+  "id": "9ae0381e-e92c-47fe-806d-a37435a75419",
+  "prevId": "e6b9f358-2f96-4725-8a2b-cb146e8a675e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#fef08a'"
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 224
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "votes": {
+          "name": "votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "voted_by": {
+          "name": "voted_by",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cards_embedding_idx": {
+          "name": "cards_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_session_id_sessions_id_fk": {
+          "name": "cards_session_id_sessions_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cards_created_by_id_users_id_fk": {
+          "name": "cards_created_by_id_users_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_participants": {
+      "name": "session_participants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_participants_user_id_users_id_fk": {
+          "name": "session_participants_user_id_users_id_fk",
+          "tableFrom": "session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_participants_session_id_sessions_id_fk": {
+          "name": "session_participants_session_id_sessions_id_fk",
+          "tableFrom": "session_participants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_participants_user_id_session_id_pk": {
+          "name": "session_participants_user_id_session_id_pk",
+          "columns": [
+            "user_id",
+            "session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "move_permission": {
+          "name": "move_permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "delete_permission": {
+          "name": "delete_permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creator'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1768088290992,
       "tag": "0007_worthless_stardust",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1769663494746,
+      "tag": "0008_uneven_loki",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/react-flow-utils.ts
+++ b/lib/react-flow-utils.ts
@@ -12,7 +12,6 @@ export interface IdeaCardNodeData extends Record<string, unknown> {
   creatorName: string;
   // UI state
   isEditing: boolean;
-  isExpanded: boolean;
   autoFocus: boolean;
 }
 
@@ -33,7 +32,6 @@ export function cardToNode(
   options?: {
     autoFocus?: boolean;
     isEditing?: boolean;
-    isExpanded?: boolean;
   },
 ): IdeaCardNode {
   return {
@@ -47,7 +45,6 @@ export function cardToNode(
       visitorId,
       creatorName,
       isEditing: options?.isEditing ?? false,
-      isExpanded: options?.isExpanded ?? false,
       autoFocus: options?.autoFocus ?? false,
     },
     draggable: true,
@@ -98,7 +95,7 @@ export function updateNodeData(
   const updatedNodes: IdeaCardNode[] = cards.map((card) => {
     const existingNode = nodeMap.get(card.id);
     if (existingNode) {
-      // Preserve UI state (isEditing, isExpanded) while updating card data
+      // Preserve UI state (isEditing) while updating card data
       return {
         ...existingNode,
         position: { x: card.x, y: card.y },
@@ -136,39 +133,42 @@ export function nodeToCard(node: IdeaCardNode): Card {
   };
 }
 
-// Card dimensions for calculations
-export const CARD_WIDTH = 224;
-export const CARD_HEIGHT = 160;
+// Default card dimensions for new cards
+export const DEFAULT_CARD_WIDTH = 224;
+export const DEFAULT_CARD_HEIGHT = 160;
+
+// Keep legacy exports for backwards compatibility
+export const CARD_WIDTH = DEFAULT_CARD_WIDTH;
+export const CARD_HEIGHT = DEFAULT_CARD_HEIGHT;
 export const CARD_WIDTH_MOBILE = 160;
 export const CARD_HEIGHT_MOBILE = 120;
 
 /**
- * Get card dimensions based on screen size
+ * Get default card dimensions based on screen size
  */
 export function getCardDimensions(isMobile: boolean) {
   return {
-    width: isMobile ? CARD_WIDTH_MOBILE : CARD_WIDTH,
-    height: isMobile ? CARD_HEIGHT_MOBILE : CARD_HEIGHT,
+    width: isMobile ? CARD_WIDTH_MOBILE : DEFAULT_CARD_WIDTH,
+    height: isMobile ? CARD_HEIGHT_MOBILE : DEFAULT_CARD_HEIGHT,
   };
 }
 
 /**
  * Calculate bounds for fitting all cards in view
+ * Uses each card's individual dimensions
  */
 export function calculateCardsBounds(
   cards: Card[],
-  isMobile: boolean,
+  _isMobile?: boolean,
 ): { minX: number; minY: number; maxX: number; maxY: number } | null {
   if (cards.length === 0) return null;
-
-  const { width, height } = getCardDimensions(isMobile);
 
   return cards.reduce(
     (acc, card) => ({
       minX: Math.min(acc.minX, card.x),
       minY: Math.min(acc.minY, card.y),
-      maxX: Math.max(acc.maxX, card.x + width),
-      maxY: Math.max(acc.maxY, card.y + height),
+      maxX: Math.max(acc.maxX, card.x + card.width),
+      maxY: Math.max(acc.maxY, card.y + card.height),
     }),
     { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
   );


### PR DESCRIPTION
## Summary

- Add resizable cards with drag handles on right edge, bottom edge, and corner
- Sync card dimensions in realtime across all users
- Fix cursor rendering to show other users' cursors at correct positions
- Fix Safari resize cursor display issue
- Fix card footer to stay at bottom when card is resized

## Changes

### Database
- Added `width` and `height` columns to cards table (defaults: 224x160)
- Migration: `drizzle/0008_uneven_loki.sql`

### Card Resize Feature
- Resize handles with min/max constraints (150x100 to 600x400)
- `resizeCard` server action with permission checks
- `card:resize` realtime event broadcasting
- Removed expand/collapse button in favor of resize

### Cursor Fixes
- Convert world coordinates to screen coordinates for proper cursor display
- Safari CSS fix using `:has()` selector and `!important` for resize cursors
- Fixed footer positioning with `mt-auto` and `flex-1` layout

## Testing
1. Open board in two browser windows
2. Resize a card - should sync to other window
3. Move mouse - cursor should appear at correct position in other window
4. Test resize cursors in Safari