### PR TITLE
fix(react-flow-board): duplicate card after resize

### DIFF
--- a/components/react-flow-board.tsx
+++ b/components/react-flow-board.tsx
@@ -713,6 +713,15 @@ function ReactFlowBoardInner({
       }
 
       const cardId = generateCardId();
+      const width = Math.max(
+        150,
+        Math.min(600, Math.round(Number(card.width) || DEFAULT_CARD_WIDTH)),
+      );
+      const height = Math.max(
+        100,
+        Math.min(400, Math.round(Number(card.height) || DEFAULT_CARD_HEIGHT)),
+      );
+
       const newCard: Card = {
         id: cardId,
         sessionId,
@@ -720,8 +729,8 @@ function ReactFlowBoardInner({
         color: card.color,
         x,
         y,
-        width: card.width,
-        height: card.height,
+        width,
+        height,
         votes: 0,
         votedBy: [],
         reactions: {},


### PR DESCRIPTION
## Summary
Duplicating a card after resizing it failed with "Failed to duplicate card" because `width`/`height` can be floats in state while the DB expects integers.

## Changes
- In `handleDuplicateCard`, round and clamp `width`/`height` to integers using the same bounds as `resizeCard` (150–600, 100–400) before creating the new card.

## Checklist
- [x] Clear description of changes
- [x] Tests pass locally
- [x] No linting errors (`bun check`)
- [ ] Documentation updated if needed (N/A)
- [ ] Screenshots for UI changes (N/A – bug fix)