### PR TITLE
fix(cards): remove setNodes call that caused infinite update loop

### DIFF
--- a/components/idea-card-node.tsx
+++ b/components/idea-card-node.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import NumberFlow from "@number-flow/react";
-import {
-  Handle,
-  type Node,
-  type NodeProps,
-  Position,
-  useReactFlow,
-} from "@xyflow/react";
+import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
 import {
   Check,
   ChevronUp,
@@ -99,7 +93,6 @@ function IdeaCardNodeComponent({
   const { card, session, userRole, visitorId, creatorName, autoFocus } =
     data as IdeaCardNodeData;
 
-  const { setNodes } = useReactFlow();
   const nodeData = data as IdeaCardNodeData;
 
   const [isEditing, setIsEditing] = useState(nodeData.isEditing);
@@ -174,23 +167,6 @@ function IdeaCardNodeComponent({
   // Fetch card editors using TanStack Query
   const { data: editorsData } = useCardEditors(card.id);
   const editors = editorsData?.editors ?? [];
-
-  // Update node data when local state changes
-  useEffect(() => {
-    setNodes((nodes: Node[]) =>
-      nodes.map((n: Node) =>
-        n.id === id
-          ? {
-              ...n,
-              data: {
-                ...(n.data as IdeaCardNodeData),
-                isEditing,
-              },
-            }
-          : n,
-      ),
-    );
-  }, [id, isEditing, setNodes]);
 
   const isDark = mounted && resolvedTheme === "dark";
   const colors = isDark ? DARK_COLORS : LIGHT_COLORS;


### PR DESCRIPTION
## Summary

- Fix React error #185 (Maximum update depth exceeded) in production
- Remove `useEffect` in `IdeaCardNode` that was syncing `isEditing` state back to node data via `setNodes`

## Problem

The `IdeaCardNode` component had a `useEffect` that called `setNodes` whenever `isEditing` changed. This created an infinite loop:

1. `setNodes` updates nodes → triggers re-render of all nodes
2. Re-render causes the `useEffect` to run again  
3. `useEffect` calls `setNodes` → repeat

## Solution

Remove the problematic `useEffect`. The `isEditing` state is purely local UI state managed by `useState` within the component - it doesn't need to be synced back to the parent's node data.

## Testing

- [x] Biome linter passes
- [x] Production build succeeds (`bun run build`)