### PR TITLE
fix(realtime): prevent React error #185 on fast typing

### DIFF
--- a/hooks/use-realtime-cards.ts
+++ b/hooks/use-realtime-cards.ts
@@ -9,7 +9,10 @@ import { createClient } from "@/lib/supabase/client";
 
 const supabase = createClient();
 
-const THROTTLE_MS = 50;
+// Throttle interval for realtime broadcasts (typing, moving, resizing)
+// Increased from 50ms to 100ms to prevent React error #185 (Maximum update depth exceeded)
+// when fast typing causes rapid state updates on receiving clients
+const THROTTLE_MS = 100;
 
 export type SessionSettings = Pick<Session, "isLocked">;
 


### PR DESCRIPTION
## Summary
- Add debouncing (100ms) to remote content sync in CardEditor to batch rapid updates
- Use `emitUpdate: false` when calling `setContent` to prevent triggering onUpdate callback loop
- Increase realtime broadcast throttle from 50ms to 100ms

## Problem
When a user types fast in a card, other clients crash with React error #185 (Maximum update depth exceeded). This happens because:
1. Fast typing triggers rapid `card:typing` broadcasts (every 50ms)
2. Receiving clients update cards state → triggers useEffect → calls setNodes
3. Node updates cause CardEditor to receive new content prop
4. `setContent` could trigger `onUpdate` → more state updates
5. React exceeds its update depth limit → crash

## Solution
1. **Debounce remote updates**: CardEditor now waits 100ms before applying remote content changes
2. **Prevent update loop**: Use `{ emitUpdate: false }` option to prevent Tiptap from triggering callbacks
3. **Reduce update frequency**: Increased broadcast throttle from 50ms to 100ms

## Testing
1. Open the app in two browser windows with the same session
2. Create a card and type very fast (mash keys)
3. Verify the other client shows updates without crashing